### PR TITLE
feat: add review comment counts to PR review statistics

### DIFF
--- a/reviewtally/main.py
+++ b/reviewtally/main.py
@@ -13,7 +13,9 @@ from reviewtally.queries.local_exceptions import (
 from .cli.parse_cmd_line import parse_cmd_line
 from .queries.get_prs import get_pull_requests_between_dates
 from .queries.get_repos_gql import get_repos_by_language
-from .queries.get_reviewers_rest import get_reviewers_for_pull_requests
+from .queries.get_reviewers_rest import (
+    get_reviewers_with_comments_for_pull_requests,
+)
 
 DEBUG_FLAG = False
 
@@ -32,7 +34,7 @@ def main() -> None:
     # map containing the reviewer name and the number of pull requests reviewed
     start_time = time.time()
     timestamped_print("Starting process")
-    reviewer_prs: dict[Any, int] = {}
+    reviewer_stats: dict[Any, dict[str, int]] = {}
     org_name, start_date, end_date, languages = parse_cmd_line()
     try:
         timestamped_print(
@@ -78,15 +80,25 @@ def main() -> None:
             pr_numbers[i: i + BATCH_SIZE] for i in range(0, len(pr_numbers), 5)
         ]
         for pr_numbers in pr_numbers_batched:
-            reviewers = get_reviewers_for_pull_requests(org_name, repo,
-                                                        pr_numbers)
-            for reviewer in reviewers:
-                if "login" not in reviewer:
+            reviewer_data = get_reviewers_with_comments_for_pull_requests(
+                org_name, repo, pr_numbers,
+            )
+            for review in reviewer_data:
+                user = review["user"]
+                if "login" not in user:
                     raise LoginNotFoundError
-                if reviewer["login"] in reviewer_prs:
-                    reviewer_prs[reviewer["login"]] += 1
-                else:
-                    reviewer_prs[reviewer["login"]] = 1
+
+                login = user["login"]
+                comment_count = review["comment_count"]
+
+                if login not in reviewer_stats:
+                    reviewer_stats[login] = {
+                        "reviews": 0,
+                        "comments": 0,
+                    }
+
+                reviewer_stats[login]["reviews"] += 1
+                reviewer_stats[login]["comments"] += comment_count
         timestamped_print(
             "Finished processing "
             f"{repo} {time.time() - start_time:.2f} seconds",
@@ -94,11 +106,14 @@ def main() -> None:
     # convert the dictionary to a list of lists and print out with tabulate
     timestamped_print(
         f"Printing results {time.time() - start_time:.2f} seconds")
-    table = [[k, v] for k, v in reviewer_prs.items()]
+    table = [
+        [login, stats["reviews"], stats["comments"]]
+        for login, stats in reviewer_stats.items()
+    ]
     # convert the dictionary to a list of lists and
     #   sort by the number of PRs reviewed
     table = sorted(table, key=lambda x: x[1], reverse=True)
-    print(tabulate(table, ["User", "total"]))  # noqa: T201
+    print(tabulate(table, ["User", "Reviews", "Comments"]))  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/reviewtally/queries/get_reviewers_rest.py
+++ b/reviewtally/queries/get_reviewers_rest.py
@@ -37,6 +37,13 @@ async def fetch_batch(urls: list[str]) -> tuple[Any]:
         return await asyncio.gather(*tasks)  # type: ignore[return-value]
 
 
+# async def fetch_review_comments_batch(urls: list[str]) -> tuple[Any]:
+#     timeout = ClientTimeout(total=REVIEWERS_TIMEOUT)
+#     async with aiohttp.ClientSession(timeout=timeout) as session:
+#         tasks = [fetch(session, url) for url in urls]
+#         return await asyncio.gather(*tasks)  # type: ignore[return-value]
+
+
 def get_reviewers_for_pull_requests(
     owner: str, repo: str, pull_numbers: list[int],
 ) -> list[dict]:
@@ -47,3 +54,59 @@ def get_reviewers_for_pull_requests(
     ]
     reviewers = asyncio.run(fetch_batch(urls))
     return [item["user"] for sublist in reviewers for item in sublist]
+
+
+def get_reviewers_with_comments_for_pull_requests(
+    owner: str, repo: str, pull_numbers: list[int],
+) -> list[dict]:
+    # First, get all reviews for the pull requests
+    review_urls = [
+        f"https://api.github.com/repos/{owner}/{repo}"
+        f"/pulls/{pull_number}/reviews"
+        for pull_number in pull_numbers
+    ]
+    reviews_response = asyncio.run(fetch_batch(review_urls))
+
+    # Collect all comment URLs for batch fetching
+    comment_urls = []
+    review_metadata = []
+
+    for i, sublist in enumerate(reviews_response):
+        pull_number = pull_numbers[i]
+        for review in sublist:
+            user = review["user"]
+            review_id = review["id"]
+
+            comment_url = (
+                f"https://api.github.com/repos/{owner}/{repo}"
+                f"/pulls/{pull_number}/reviews/{review_id}/comments"
+            )
+            comment_urls.append(comment_url)
+            review_metadata.append({
+                "user": user,
+                "review_id": review_id,
+                "pull_number": pull_number,
+            })
+
+    # Fetch all comments in batches
+    if comment_urls:
+        comments_response = asyncio.run(
+            fetch_batch(comment_urls),
+        )
+
+        # Combine the data
+        reviewer_data = []
+        for i, comments in enumerate(comments_response):
+            metadata = review_metadata[i]
+            comment_count = len(comments) if comments else 0
+
+            reviewer_data.append({
+                "user": metadata["user"],
+                "review_id": metadata["review_id"],
+                "pull_number": metadata["pull_number"],
+                "comment_count": comment_count,
+            })
+
+        return reviewer_data
+
+    return []


### PR DESCRIPTION
## Summary
- Enhanced the review-tally tool to display the number of review comments alongside review counts
- Added new function `get_reviewers_with_comments_for_pull_requests()` to fetch comment data
- Updated output table to show both "Reviews" and "Comments" columns
- Maintained efficient batch processing for GitHub API calls

## Changes Made
- **reviewtally/queries/get_reviewers_rest.py**: Added new function to fetch review comments per PR review using GitHub's review comments API
- **reviewtally/main.py**: Updated data structures and output formatting to track and display comment counts

## Test Plan
- [x] Code passes linting with `ruff check .`
- [x] Code passes type checking with `mypy reviewtally/`
- [ ] Manual testing with a real GitHub organization to verify comment counts
- [ ] Verify performance with repositories containing many PR reviews

🤖 Generated with [Claude Code](https://claude.ai/code)