### PR TITLE
feat: add comments-to-review ratio metric

### DIFF
--- a/reviewtally/main.py
+++ b/reviewtally/main.py
@@ -108,10 +108,11 @@ def main() -> None:
         f"Printing results {time.time() - start_time:.2f} seconds")
     table = [
         [
-            login, 
-            stats["reviews"], 
+            login,
+            stats["reviews"],
             stats["comments"],
-            f"{stats['comments'] / stats['reviews']:.1f}" if stats["reviews"] > 0 else "0.0"
+            f"{stats['comments'] / stats['reviews']:.1f}"
+                if stats["reviews"] > 0 else "0.0",
         ]
         for login, stats in reviewer_stats.items()
     ]

--- a/reviewtally/main.py
+++ b/reviewtally/main.py
@@ -107,13 +107,18 @@ def main() -> None:
     timestamped_print(
         f"Printing results {time.time() - start_time:.2f} seconds")
     table = [
-        [login, stats["reviews"], stats["comments"]]
+        [
+            login, 
+            stats["reviews"], 
+            stats["comments"],
+            f"{stats['comments'] / stats['reviews']:.1f}" if stats["reviews"] > 0 else "0.0"
+        ]
         for login, stats in reviewer_stats.items()
     ]
     # convert the dictionary to a list of lists and
     #   sort by the number of PRs reviewed
     table = sorted(table, key=lambda x: (x[1],x[2]), reverse=True)
-    print(tabulate(table, ["User", "Reviews", "Comments"]))  # noqa: T201
+    print(tabulate(table, ["User", "Reviews", "Comments", "Avg Comments"]))  # noqa: T201
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add average comments per review column to output table
- Provides insight into review thoroughness and engagement levels
- Helps distinguish between approval-only reviewers and those providing detailed feedback

## Changes
- Enhanced table output with "Avg Comments" column showing comments/reviews ratio
- Safe division handling to prevent divide-by-zero errors
- Formatted to 1 decimal place for clean display

## Example Output
```
User     Reviews  Comments  Avg Comments
alice    5        15        3.0
bob      3        6         2.0
charlie  0        0         0.0
```

## Test plan
- [x] Test ratio calculation with sample data
- [x] Verify division by zero handling
- [x] Confirm output formatting

🤖 Generated with [Claude Code](https://claude.ai/code)