### PR TITLE
refactor: move get_repositories_safely to get_repos_gql module

### DIFF
--- a/reviewtally/main.py
+++ b/reviewtally/main.py
@@ -16,7 +16,7 @@ from reviewtally.queries.local_exceptions import (
 from .cli.parse_cmd_line import parse_cmd_line
 from .queries.get_prs import get_pull_requests_between_dates
 from .queries.get_repos_gql import (
-    get_repositories_safely,
+    get_repos,
 )
 from .queries.get_reviewers_rest import (
     get_reviewers_with_comments_for_pull_requests,
@@ -205,7 +205,7 @@ def main() -> None:
         f"Calling get_repos_by_language {time.time() - start_time:.2f} "
         "seconds",
     )
-    repo_list = get_repositories_safely(org_name, languages)
+    repo_list = get_repos(org_name, languages)
     if repo_list is None:
         return
     repo_names = tqdm(repo_list)

--- a/reviewtally/main.py
+++ b/reviewtally/main.py
@@ -10,14 +10,14 @@ from tabulate import tabulate
 from tqdm import tqdm
 
 from reviewtally.queries.local_exceptions import (
-    GitHubTokenNotDefinedError,
     LoginNotFoundError,
-    NoGitHubOrgError,
 )
 
 from .cli.parse_cmd_line import parse_cmd_line
 from .queries.get_prs import get_pull_requests_between_dates
-from .queries.get_repos_gql import get_repos_by_language
+from .queries.get_repos_gql import (
+    get_repositories_safely,
+)
 from .queries.get_reviewers_rest import (
     get_reviewers_with_comments_for_pull_requests,
 )
@@ -72,18 +72,6 @@ METRIC_INFO = {
     },
 }
 
-
-def get_repositories_safely(
-    org_name: str, languages: list[str],
-) -> list[str] | None:
-    try:
-        return list(get_repos_by_language(org_name, languages))
-    except GitHubTokenNotDefinedError as e:
-        print("Error:", e)  # noqa: T201
-        return None
-    except NoGitHubOrgError as e:
-        print("Error:", e)  # noqa: T201
-        return None
 
 
 def collect_review_data(

--- a/reviewtally/queries/get_repos_gql.py
+++ b/reviewtally/queries/get_repos_gql.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import requests
@@ -63,3 +65,16 @@ def get_repos_by_language(org: str, languages: list[str]) -> list[str]:
                 [language.lower() for language in languages]
             for node in repo["languages"]["nodes"])
     ]
+
+
+def get_repositories_safely(
+    org_name: str, languages: list[str],
+) -> list[str] | None:
+    try:
+        return list(get_repos_by_language(org_name, languages))
+    except GitHubTokenNotDefinedError as e:
+        print("Error:", e)  # noqa: T201
+        return None
+    except NoGitHubOrgError as e:
+        print("Error:", e)  # noqa: T201
+        return None

--- a/reviewtally/queries/get_repos_gql.py
+++ b/reviewtally/queries/get_repos_gql.py
@@ -67,7 +67,7 @@ def get_repos_by_language(org: str, languages: list[str]) -> list[str]:
     ]
 
 
-def get_repositories_safely(
+def get_repos(
     org_name: str, languages: list[str],
 ) -> list[str] | None:
     try:


### PR DESCRIPTION
## Summary
- Move `get_repositories_safely` function from `main.py` to `get_repos_gql.py`
- Group related repository functionality together for better code organization
- Clean up unused imports in main.py

## Test plan
- [x] All existing tests pass
- [x] Function import works correctly
- [x] Code linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)