### PR TITLE
feat: add time-based metrics (response-time, completion-time, active-days)

### DIFF
--- a/reviewtally/cli/parse_cmd_line.py
+++ b/reviewtally/cli/parse_cmd_line.py
@@ -49,7 +49,7 @@ def parse_cmd_line() -> [str, datetime, datetime, list[str], list[str]]:  # type
     # add the metrics selection argument
     metrics_help = (
         "Comma-separated list of metrics to display "
-        "(reviews,comments,avg-comments,engagement,thoroughness)"
+        "(reviews,comments,avg-comments,engagement,thoroughness,response-time,completion-time,active-days)"
     )
     parser.add_argument("-m", "--metrics", required=False,
                         default="reviews,comments,avg-comments",

--- a/reviewtally/queries/get_reviewers_rest.py
+++ b/reviewtally/queries/get_reviewers_rest.py
@@ -142,6 +142,7 @@ def get_reviewers_with_comments_for_pull_requests(
                 "user": user,
                 "review_id": review_id,
                 "pull_number": pull_number,
+                "submitted_at": review["submitted_at"],
             })
 
     # Fetch all comments in batches
@@ -161,6 +162,7 @@ def get_reviewers_with_comments_for_pull_requests(
                 "review_id": metadata["review_id"],
                 "pull_number": metadata["pull_number"],
                 "comment_count": comment_count,
+                "submitted_at": metadata["submitted_at"],
             })
 
         return reviewer_data


### PR DESCRIPTION
## Summary
- Add Phase 2 time-based metrics for reviewer response pattern analysis
- **response-time**: Average time from PR creation to first review
- **completion-time**: Time span from first to last review  
- **active-days**: Number of unique days with review activity

## Key Features
- Human-readable time formatting (45m, 2.5h, 1.2d)
- CLI integration via `-m/--metrics` parameter
- No additional API calls (leverages existing timestamp data)
- Backwards compatible with all existing functionality

## Usage Examples
```bash
# Include time metrics
review-tally -o myorg -m reviews,comments,response-time,active-days

# All metrics including time-based
review-tally -o myorg -m reviews,comments,avg-comments,engagement,thoroughness,response-time,completion-time,active-days
```

## Test Plan
- [x] All existing tests pass
- [x] Ruff linting clean
- [x] MyPy type checking passes
- [x] CLI help shows new metrics options
- [x] Backwards compatibility maintained
- [x] Time formatting works correctly (0h, 45m, 2.5h, 1.2d)

🤖 Generated with [Claude Code](https://claude.ai/code)