### PR TITLE
fix: Remove invalid avg_comments_per_review metric from individual plot options

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ review-tally -o expressjs -l javascript --plot-individual --save-plot reviewer_d
 ### Available metrics for pie charts:
 - `reviews` - Number of reviews per reviewer (default)
 - `comments` - Number of comments per reviewer
-- `avg_comments_per_review` - Average comments per review
 - `engagement_level` - Engagement level (High/Medium/Low)
 - `thoroughness_score` - Thoroughness percentage score
 - `avg_response_time_hours` - Average response time in hours
@@ -133,7 +132,7 @@ review-tally -o expressjs -l javascript --plot-individual --save-plot reviewer_d
 * --chart-metrics Comma-separated sprint metrics to plot. Default: total_reviews,total_comments. Available: total_reviews,total_comments,unique_reviewers,avg_comments_per_review,reviews_per_reviewer,avg_response_time_hours,avg_completion_time_hours,active_review_days
 * --save-plot Optional path to save the interactive HTML chart
 * --plot-individual Generate pie charts showing individual reviewer metric distribution (opens in browser)
-* --individual-chart-metric Metric to visualize in individual pie chart. Default: reviews. Available: reviews,comments,avg_comments_per_review,engagement_level,thoroughness_score,avg_response_time_hours,avg_completion_time_hours,active_review_days
+* --individual-chart-metric Metric to visualize in individual pie chart. Default: reviews. Available: reviews,comments,engagement_level,thoroughness_score,avg_response_time_hours,avg_completion_time_hours,active_review_days
 * --no-cache Disable PR review caching (always fetch fresh data from API). By default, caching is enabled for better performance.
 
 ## GitHub API Rate Limiting

--- a/reviewtally/cli/parse_cmd_line.py
+++ b/reviewtally/cli/parse_cmd_line.py
@@ -146,7 +146,7 @@ def parse_cmd_line() -> CommandLineArgs:  # noqa: C901, PLR0912, PLR0915
     )
     parser.add_argument(
         "--individual-chart-metric",
-        choices=["reviews", "comments", "avg_comments_per_review",
+        choices=["reviews", "comments",
                 "engagement_level", "thoroughness_score",
                 "avg_response_time_hours", "avg_completion_time_hours",
                 "active_review_days"],

--- a/reviewtally/visualization/individual_plot.py
+++ b/reviewtally/visualization/individual_plot.py
@@ -8,7 +8,6 @@ import plotly.io as pio  # type: ignore[import]
 SUPPORTED_INDIVIDUAL_METRICS = {
     "reviews": "Reviews",
     "comments": "Comments",
-    "avg_comments_per_review": "Avg Comments/Review",
     "engagement_level": "Engagement Level",
     "thoroughness_score": "Thoroughness Score",
     "avg_response_time_hours": "Avg Response Time (hrs)",


### PR DESCRIPTION
## Summary
- Remove `avg_comments_per_review` from `SUPPORTED_INDIVIDUAL_METRICS` dictionary in `individual_plot.py`
- Remove `avg_comments_per_review` from CLI choices in `parse_cmd_line.py`
- Update README.md to remove `avg_comments_per_review` from available metrics documentation

## Problem
The `avg_comments_per_review` key does not exist in the `reviewer_stats` dictionary. It's calculated on-the-fly in `output_formatting.py` but never stored as a field, making it invalid for use in individual plots.

## Test plan
- [ ] Verify `--individual-chart-metric` CLI argument no longer accepts `avg_comments_per_review`
- [ ] Test that valid metrics still work: `--individual-chart-metric comments`, `--individual-chart-metric engagement_level`
- [ ] Confirm documentation matches available options

🤖 Generated with [Claude Code](https://claude.com/claude-code)