### PR TITLE
fix: Use absolute URLs for images to support PyPI rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ review-tally -o expressjs -l javascript --sprint-analysis --plot-sprint --output
 ```
 
 ### Example: Sprint bar chart for expressjs
-![Sprint Analysis Bar Chart](docs/expressjs-bar-sprint-data.png)
+![Sprint Analysis Bar Chart](https://raw.githubusercontent.com/ghinks/review-tally/main/docs/expressjs-bar-sprint-data.png)
 
 ## Individual Reviewer Visualization
 The tool can generate pie charts showing the distribution of metrics across individual reviewers. Use `--plot-individual` to create interactive pie charts that open in your browser.
@@ -110,7 +110,7 @@ review-tally -o expressjs -l javascript --plot-individual --save-plot reviewer_d
 ```
 
 ### Example: Comment distribution pie chart for expressjs
-![Individual Reviewer Pie Chart](docs/expressjs-pie-num-comments.png)
+![Individual Reviewer Pie Chart](https://raw.githubusercontent.com/ghinks/review-tally/main/docs/expressjs-pie-num-comments.png)
 
 ### Available metrics for pie charts:
 - `reviews` - Number of reviews per reviewer (default)


### PR DESCRIPTION
## Summary
- Changed image paths from relative to absolute GitHub URLs
- Images will now display correctly on both GitHub and PyPI.org

## Context
PyPI doesn't support relative image paths, so images in the README weren't appearing on the package page. Using absolute URLs to raw GitHub content solves this issue.

## Test plan
- [ ] Verify images still display correctly on GitHub
- [ ] After merge to main, verify images appear on PyPI.org package page

🤖 Generated with [Claude Code](https://claude.com/claude-code)