### PR TITLE
chore: Increase retry configuration for better resilience

### DIFF
--- a/reviewtally/queries/__init__.py
+++ b/reviewtally/queries/__init__.py
@@ -22,10 +22,10 @@ SSL_CONTEXT.minimum_version = ssl.TLSVersion.TLSv1_2  # Minimum TLS version
 SSL_CONTEXT.maximum_version = ssl.TLSVersion.TLSv1_3  # Maximum TLS version
 
 # Retry configuration for handling transient failures
-MAX_RETRIES = 3                    # Maximum number of retry attempts
+MAX_RETRIES = 10                  # Maximum number of retry attempts
 INITIAL_BACKOFF = 1.0             # Initial backoff delay in seconds
 BACKOFF_MULTIPLIER = 2.0          # Exponential backoff multiplier
-MAX_BACKOFF = 60.0                # Maximum backoff delay in seconds
+MAX_BACKOFF = 600.0               # Maximum backoff delay in seconds
 
 # HTTP status codes that should trigger retries
 RETRYABLE_STATUS_CODES = {


### PR DESCRIPTION
## Summary

- Increase MAX_RETRIES from 3 to 10 attempts for better handling of transient failures
- Increase MAX_BACKOFF from 60 seconds to 600 seconds (10 minutes) for rate limiting scenarios
- Improves application resilience when interacting with GitHub API

## Changes

**Configuration updates:**
- `reviewtally/queries/__init__.py` - Updated MAX_RETRIES: 3 → 10
- `reviewtally/queries/__init__.py` - Updated MAX_BACKOFF: 60s → 600s

## Motivation

When processing large organizations with many repositories, the application may encounter:
- Transient network failures
- GitHub API rate limiting (429 responses)
- Temporary service unavailability (502, 503, 504 responses)

By increasing the retry count and maximum backoff time, the application can better handle these scenarios without requiring manual intervention, especially for long-running queries against organizations with extensive PR histories.

## Test Plan

- [x] Configuration values updated correctly
- [x] No functional code changes, only configuration constants
- [x] Existing retry logic will use new values automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)