### PR TITLE
feat: detect GitHub search limit of 1000 items

### DIFF
--- a/reviewtally/exceptions/local_exceptions.py
+++ b/reviewtally/exceptions/local_exceptions.py
@@ -52,3 +52,15 @@ class PaginationError(Exception):
     def __init__(self, message: str) -> None:
         """Initialize the exception string."""
         super().__init__(f"Pagination error: {message}")
+
+
+class SearchLimitReachedError(Exception):
+    """Exception raised when GitHub search limit (1000 items) is reached."""
+
+    def __init__(self, total_count: int) -> None:
+        """Initialize the exception string."""
+        super().__init__(
+            f"GitHub search limit reached: {total_count} results found, "
+            "but only the first 1000 are accessible. "
+            "Please narrow your date range.",
+        )

--- a/reviewtally/queries/get_prs.py
+++ b/reviewtally/queries/get_prs.py
@@ -13,7 +13,10 @@ if TYPE_CHECKING:
     from reviewtally.cache.cache_manager import CacheManager
 
 from reviewtally.cache.cache_manager import get_cache_manager
-from reviewtally.exceptions.local_exceptions import PaginationError
+from reviewtally.exceptions.local_exceptions import (
+    PaginationError,
+    SearchLimitReachedError,
+)
 from reviewtally.queries import (
     BACKOFF_MULTIPLIER,
     GENERAL_TIMEOUT,
@@ -27,6 +30,7 @@ from reviewtally.queries import (
 
 MAX_NUM_PAGES = 100
 ITEMS_PER_PAGE = 100
+GITHUB_SEARCH_LIMIT = 1000
 RATE_LIMIT_REMAINING_THRESHOLD = 10  # arbitrary threshold
 RATE_LIMIT_SLEEP_SECONDS = 60  # seconds to sleep if rate limit is hit
 
@@ -167,6 +171,12 @@ def fetch_pull_requests_from_github(
         response_data = _make_pr_request_with_retry(url, headers, params)
         # Search API returns {"items": [...]} instead of direct array
         if isinstance(response_data, dict):
+            # Detect 1000 item limit on the first page
+            if page == 1:
+                total_count = response_data.get("total_count", 0)
+                if total_count > GITHUB_SEARCH_LIMIT:
+                    raise SearchLimitReachedError(total_count)
+
             prs = response_data.get("items", [])
         else:
             prs = []  # Unexpected format, skip this page

--- a/tests/test_get_prs.py
+++ b/tests/test_get_prs.py
@@ -3,7 +3,10 @@ import unittest
 from datetime import datetime, timezone
 from unittest.mock import Mock, patch
 
-from reviewtally.exceptions.local_exceptions import PaginationError
+from reviewtally.exceptions.local_exceptions import (
+    PaginationError,
+    SearchLimitReachedError,
+)
 from reviewtally.queries import build_github_rest_api_url, set_github_host
 from reviewtally.queries.get_prs import get_pull_requests_between_dates
 
@@ -113,6 +116,28 @@ class TestGetPullRequestsBetweenDates(unittest.TestCase):
 
         with self.assertRaises(PaginationError):
             get_pull_requests_between_dates(owner, repo, start_date, end_date)
+
+    @patch("requests.get")
+    @patch.dict(os.environ, {"GITHUB_TOKEN": "test-token"})
+    def test_search_limit_reached(self, mock_get) -> None:  # noqa: ANN001
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.headers = {}
+        mock_response.json.return_value = {
+            "total_count": 1200,
+            "items": [{"number": 1}],
+        }
+        mock_get.return_value = mock_response
+
+        owner = "test_owner"
+        repo = "test_repo"
+        start_date = datetime(2023, 1, 1, tzinfo=timezone.utc)
+        end_date = datetime(2023, 1, 2, tzinfo=timezone.utc)
+
+        with self.assertRaises(SearchLimitReachedError) as cm:
+            get_pull_requests_between_dates(owner, repo, start_date, end_date)
+
+        self.assertIn("1200 results found", str(cm.exception))
 
     @patch("requests.get")
     @patch.dict(os.environ, {"GITHUB_TOKEN": "test-token"})


### PR DESCRIPTION
Added SearchLimitReachedError to handle cases where the GitHub Search API returns
more than 1000 results, which is the limit for accessible results. This will
allow for future implementation of date-range chunking to bypass this limit.
